### PR TITLE
영양제 추가화면 폰트 크기 iPad 대응 (SCRUM-250)

### DIFF
--- a/Meditory/Meditory/Extension/CGFloat+Extension.swift
+++ b/Meditory/Meditory/Extension/CGFloat+Extension.swift
@@ -5,7 +5,7 @@
 //  Created by 홍승아 on 8/5/25.
 //
 
-import Foundation
+import UIKit
 
 extension CGFloat {
   // MARK: - Spacing
@@ -16,4 +16,7 @@ extension CGFloat {
   // MARK: - CornerRadius
   static let smallRadius: CGFloat = 10
   static let defaultRadius: CGFloat = 20
+  
+  // MARK: - FontSize
+  static let defaultFontSize: CGFloat = UIDevice.isPad ? 23 : 18
 }

--- a/Meditory/Meditory/Extension/CGFloat+Extension.swift
+++ b/Meditory/Meditory/Extension/CGFloat+Extension.swift
@@ -10,7 +10,7 @@ import UIKit
 extension CGFloat {
   // MARK: - Spacing
   static let smallSpacing: CGFloat = 8
-  static let defaultSpacing: CGFloat = 16
+  static let defaultSpacing: CGFloat = UIDevice.isPad ? 20 : 16
   static let bottomInset: CGFloat = 33
   
   // MARK: - CornerRadius

--- a/Meditory/Meditory/Features/AddIntake/Model/AddIntakeItem.swift
+++ b/Meditory/Meditory/Features/AddIntake/Model/AddIntakeItem.swift
@@ -5,7 +5,7 @@
 //  Created by 홍승아 on 8/21/25.
 //
 
-import Foundation
+import UIKit
 
 enum AddIntakeItem: String, CaseIterable {
   case supplement
@@ -18,7 +18,7 @@ enum AddIntakeItem: String, CaseIterable {
   var title: String {
     switch self {
     case .supplement:
-      return "영양제 추가"
+      return UIDevice.isPad ? "복용 약\n추가" : "복용 약 추가"
     case .meal:
       return "식단 추가"
     }

--- a/Meditory/Meditory/Features/AddIntake/View/AddIntakeSelectorPadView.swift
+++ b/Meditory/Meditory/Features/AddIntake/View/AddIntakeSelectorPadView.swift
@@ -111,6 +111,7 @@ extension AddIntakeSelectorPadView {
         .foregroundStyle(.white)
         .frame(width: AddIntakeButton.size.width)
         .font(.notoSans(size: 17))
+        .multilineTextAlignment(.center)
     }
     .onTapGesture {
       selectedIntakeItem = item

--- a/Meditory/Meditory/Features/AddSupplement/Components/AlertView.swift
+++ b/Meditory/Meditory/Features/AddSupplement/Components/AlertView.swift
@@ -10,54 +10,21 @@ import SwiftUI
 struct AlertView: View {
   
   enum AlertType {
-    case cancel
     case confirm
-    case confirmCancel
+    case delete
   }
   
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
   var alertType: AlertType = .confirm
   var title: String
   var message: String
   var onConfirm: (() -> Void)?
   var onCancel: (() -> Void)?
-  
-  @State private var isPresented = false
-  
-  private var confirmButton: some View {
-    Button {
-      onConfirm?()
-      isPresented = false
-    } label: {
-      Text("확인")
-        .font(.notoSans(size: 18))
-        .frame(maxWidth: .infinity)
-        .foregroundStyle(.gray)
-        .padding(.vertical, .smallSpacing)
-        .contentShape(Rectangle())
-    }
-    .buttonStyle(.plain)
-    .background(Color.secondary.opacity(0.2))
-    .overlay(
-      RoundedRectangle(cornerRadius: .smallRadius, style: .continuous)
-        .stroke(Color(.systemGray4), lineWidth: 1)
-    )
-    .cornerRadius(.smallRadius)
-  }
-  
-  private var cancelButton: some View {
-    Button {
-      onCancel?()
-      isPresented = false
-    } label: {
-      Text("취소")
-        .font(.notoSans(size: 18))
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, .smallSpacing)
-    }
-    .foregroundStyle(.white)
-    .background(Color.main)
-    .cornerRadius(.smallRadius)
-  }
+  var onDelete: (() -> Void)?
+
+  private var isPadStyle: Bool { horizontalSizeClass == .regular }
+  private var maxCardWidth: CGFloat { isPadStyle ? 520 : .infinity }
   
   var body: some View {
     ZStack {
@@ -80,30 +47,65 @@ struct AlertView: View {
         }
         
         switch alertType {
-        case .cancel:
-          cancelButton
         case .confirm:
-          confirmButton
-        case .confirmCancel:
+          confirmButton("확인", onConfirm)
+        case .delete:
           HStack(spacing: .defaultSpacing) {
-            confirmButton
+            confirmButton("아니오", onCancel)
             
-            cancelButton
+            deleteButton("삭제", onDelete)
           }
         }
       }
       .padding(.defaultSpacing + 8)
-      .background(.regularMaterial)
-      .cornerRadius(.defaultRadius)
-      .modifier(UnifiedShadow())
-      .padding(.horizontal, .defaultSpacing * 2)
-      .accessibilityElement(children: .contain)
-      .accessibilityAddTraits(.isModal)
+      .frame(maxWidth: maxCardWidth, alignment: .center)
+      .background(
+        RoundedRectangle(cornerRadius: .defaultRadius, style: .continuous)
+          .fill(.regularMaterial)
+      )
+      .shadow(color: .black.opacity(0.15), radius: 20, x: 0, y: 10)
+      .padding(.horizontal, .defaultSpacing)
+      .zIndex(1000)
     }
-    .transition(.scale.combined(with: .opacity))
-    .animation(.spring(response: 0.35, dampingFraction: 0.9), value: isPresented)
-    .onAppear {
-      isPresented = true
+    .transition(.opacity)
+    .zIndex(1000)
+  }
+}
+
+
+// MARK: - Subviews
+extension AlertView {
+  private func text(_ title: String) -> some View {
+    Text(title)
+      .font(.notoSans(size: .defaultFontSize))
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, .smallSpacing)
+      .contentShape(Rectangle())
+  }
+  
+  private func confirmButton(_ title: String, _ action: (() -> Void)?) -> some View {
+    Button {
+      action?()
+    } label: {
+      text(title)
     }
+    .buttonStyle(.plain)
+    .background(Color.secondary.opacity(0.16))
+    .overlay(
+      RoundedRectangle(cornerRadius: .smallRadius, style: .continuous)
+        .stroke(Color(.systemGray4), lineWidth: 1)
+    )
+    .cornerRadius(.smallRadius)
+  }
+  
+  private func deleteButton(_ title: String, _ action: (() -> Void)?) -> some View {
+    Button {
+      action?()
+    } label: {
+      text(title)
+    }
+    .foregroundStyle(.white)
+    .background(Color.red)
+    .cornerRadius(.smallRadius)
   }
 }

--- a/Meditory/Meditory/Features/AddSupplement/Components/InputTextField.swift
+++ b/Meditory/Meditory/Features/AddSupplement/Components/InputTextField.swift
@@ -12,7 +12,7 @@ struct InputTextField: UIViewRepresentable {
   
   @Binding var text: String
   
-  let font: UIFont? = .notoSans(size: 16)
+  let font: UIFont? = .notoSans(size: UIDevice.isPad ? 20 : 16)
   let placeHolder: String
   let placHolderTextColor: UIColor = .textGray
   let tintColor: UIColor = .textGray

--- a/Meditory/Meditory/Features/AddSupplement/View/AIRecommendedScheduleView.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/AIRecommendedScheduleView.swift
@@ -40,8 +40,8 @@ struct AIRecommendedScheduleView: View {
   
   @Environment(\.modelContext) private var context
   @Environment(\.colorScheme) private var colorScheme
+  private let isPad = UIDevice.isPad
   
-  let defaultFontSize: CGFloat
   let supplementSummary: SupplementSummary?
   let lifestyle: UserLifeStyleDTO
   
@@ -53,12 +53,10 @@ struct AIRecommendedScheduleView: View {
   @State private var isInitiallyCreated: Bool
   
   init(
-    defaultFontSize: CGFloat,
     supplementSummary: SupplementSummary?,
     lifestyle: UserLifeStyleDTO?,
     supplement: Binding<SupplementDTO?>
   ) {
-    self.defaultFontSize = defaultFontSize
     self.supplementSummary = supplementSummary
     self.lifestyle = lifestyle ?? .standard
     self._supplement = supplement
@@ -89,7 +87,7 @@ struct AIRecommendedScheduleView: View {
           .frame(width: 20, height: 20)
         
         Text("AI 추천 복용 스케줄")
-          .font(.notoSans(size: defaultFontSize))
+          .font(.notoSans(size: .defaultFontSize))
         
         Spacer()
         
@@ -104,14 +102,14 @@ struct AIRecommendedScheduleView: View {
           requestAISchedule()
         } label: {
           Text("생성하기")
-            .font(.notoSans(size: defaultFontSize))
+            .font(.notoSans(size: .defaultFontSize))
             .foregroundStyle(.main)
         }
         
         switch reason {
         case .missingSupplementInput, .networkFailed:
           Text(reason.description)
-            .font(.notoSans(weight: .regular, size: 13))
+            .font(.notoSans(weight: .regular, size: .defaultFontSize - 5))
             .foregroundStyle(.textGray)
             .padding(.top, 4)
             .multilineTextAlignment(.center)
@@ -135,7 +133,7 @@ struct AIRecommendedScheduleView: View {
         VStack(alignment: .leading, spacing: .smallSpacing) {
           ForEach(Array(scales.enumerated()), id: \.offset) { idx, scale in
             ShimmerView(widthRatio: scale)
-              .frame(height: 15)
+              .frame(height: isPad ? 18 : 15)
           }
         }
       case .created:
@@ -184,36 +182,36 @@ struct AIRecommendedScheduleView: View {
 extension AIRecommendedScheduleView {
   private func scheduleInfoRow(index: Int, doseTime: DoseTime) -> some View {
     HStack(spacing: .defaultSpacing) {
+      let circleWidth: CGFloat = isPad ? 25 : 18
+      
       ZStack {
         Circle()
           .fill(.main)
-          .frame(width: 18, height: 18)
+          .frame(width: circleWidth, height: circleWidth)
         
         Text("\(index + 1)")
-          .font(.notoSans(weight: .bold, size: 10))
+          .font(.notoSans(weight: .bold, size: .defaultFontSize - 8))
           .foregroundStyle(.white)
           .padding(.bottom, 1)
       }
       
       Text(doseTime.timeString)
-        .font(.notoSans(weight: .regular, size: defaultFontSize))
+        .font(.notoSans(weight: .regular, size: .defaultFontSize))
         .padding(.bottom, 2)
       
       HStack(spacing: 4) {
-        let fontSize: CGFloat = 12
-        
         Text(doseTime.relativeTo)
-          .font(.notoSans(weight: .semiBold, size: fontSize))
+          .font(.notoSans(weight: .semiBold, size: .defaultFontSize - 6))
           .foregroundStyle(.main)
         
         if doseTime.isNotNone {
           Text(doseTime.relativeTimeDescription)
-            .font(.notoSans(size: fontSize))
+            .font(.notoSans(size: .defaultFontSize - 6))
             .foregroundStyle(.main)
         }
       }
-      .padding(.horizontal, .smallSpacing)
-      .padding(.vertical, 2)
+      .padding(.horizontal, isPad ? .smallSpacing + 4 : .smallSpacing)
+      .padding(.vertical, isPad ? 4 : 2)
       .background(
         Capsule()
           .fill(.sub.opacity(0.18))
@@ -222,7 +220,7 @@ extension AIRecommendedScheduleView {
       Spacer()
       
       Text(doseTime.doseString)
-        .font(.notoSans(weight: .regular, size: defaultFontSize))
+        .font(.notoSans(weight: .regular, size: .defaultFontSize))
         .foregroundStyle(.textGray)
         .padding(.bottom, 2)
     }
@@ -238,13 +236,12 @@ extension AIRecommendedScheduleView {
         requestAISchedule()
       } label: {
         HStack(spacing: .zero) {
-          let fontSize: CGFloat = 13
           Text(prefixText)
-            .font(.notoSans(weight: .regular, size: fontSize))
+            .font(.notoSans(weight: .regular, size: .defaultFontSize - 5))
             .foregroundStyle(.textGray)
           
           Text(actionText)
-            .font(.notoSans(size: fontSize))
+            .font(.notoSans(size: .defaultFontSize - 5))
             .foregroundStyle(.main)
         }
         .padding(.bottom, .smallSpacing)

--- a/Meditory/Meditory/Features/AddSupplement/View/AIRecommendedScheduleView.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/AIRecommendedScheduleView.swift
@@ -114,6 +114,7 @@ struct AIRecommendedScheduleView: View {
             .font(.notoSans(weight: .regular, size: 13))
             .foregroundStyle(.textGray)
             .padding(.top, 4)
+            .multilineTextAlignment(.center)
             .modifier(
               ShakeEffect(
                 amplitude: 1,

--- a/Meditory/Meditory/Features/AddSupplement/View/AddSupplementView.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/AddSupplementView.swift
@@ -32,6 +32,7 @@ struct AddSupplementView: View {
   @Environment(\.modelContext) private var context
   @Environment(\.dismiss) private var dismiss
   @Environment(\.colorScheme) private var colorScheme
+  private let isPad = UIDevice.isPad
   
   // Query
   @Query private var users: [User]
@@ -70,9 +71,6 @@ struct AddSupplementView: View {
   @State private var showAlert = false
   @State private var isSaving = false
   
-  // Constants
-  private let defaultFontSize: CGFloat = 18
-
   // Edit 시 사용하는 루틴
   private let editingRoutine: Routine?
   
@@ -135,7 +133,7 @@ struct AddSupplementView: View {
 // MARK: - Main Content and Subviews
 extension AddSupplementView {
   private func mainContentView(for user: User) -> some View {
-    VStack(spacing: 20) {
+    VStack(spacing: isPad ? 30 : 20) {
       supplementNameInput()
       
       supplementInfoSection()
@@ -217,7 +215,6 @@ extension AddSupplementView {
   private func supplementInfoSection() -> some View {
     if shouldShowSupplementInfo {
       SupplementInfoView(
-        defaultFontSize: defaultFontSize,
         addSupplementVM: addSupplementVM,
         isSearchingSupplementSummary: $isSearchingSupplementSummary
       )
@@ -228,7 +225,6 @@ extension AddSupplementView {
     Group {
       LifestyleTimeView(
         type: .dailyCycle,
-        defaultFontSize: defaultFontSize,
         lifestyleTimeItems: lifestyleTimeVM.lifestyleTimeItems(for: .dailyCycle),
         onTapGesture: { option in
           selectedLifestyleCategory = .dailyCycle
@@ -239,7 +235,6 @@ extension AddSupplementView {
       
       LifestyleTimeView(
         type: .meal,
-        defaultFontSize: defaultFontSize,
         lifestyleTimeItems: lifestyleTimeVM.lifestyleTimeItems(for: .meal),
         onTapGesture: { option in
           selectedLifestyleCategory = .meal
@@ -275,7 +270,7 @@ extension AddSupplementView {
         HStack {
           ForEach(SupplementScheduleType.allCases, id: \.self) { type in
             Text(type.title)
-              .font(.notoSans(size: 15))
+              .font(.notoSans(size: .defaultFontSize - 3))
               .foregroundStyle(textColor(for: type))
               .frame(width: buttonSize.width, height: buttonSize.height)
               .contentShape(Rectangle())
@@ -293,7 +288,7 @@ extension AddSupplementView {
       }
       .cardStyle(cornerRadius: 10)
     }
-    .frame(height: 40)
+    .frame(height: isPad ? 50 : 40)
   }
   
   private func scheduleDetailsSection() -> some View {
@@ -313,12 +308,12 @@ extension AddSupplementView {
   private func weekdayScheduleView() -> some View {
     HStack {
       Text("복용 요일")
-        .font(.notoSans(size: defaultFontSize))
+        .font(.notoSans(size: .defaultFontSize))
       
       Spacer()
       
       Text(addSupplementVM.weekdaysString)
-        .font(.notoSans(size: defaultFontSize))
+        .font(.notoSans(size: .defaultFontSize))
         .padding(.bottom, 2)
         .foregroundStyle(.textGray)
     }
@@ -330,9 +325,14 @@ extension AddSupplementView {
   
   private func intervalScheduleView() -> some View {
     VStack {
+      let rectangleSize = CGSize(
+        width: .defaultFontSize + 30,
+        height: .defaultFontSize + 18
+      )
+      
       HStack(spacing: 8) {
         Text("시작 날짜")
-          .font(.notoSans(size: defaultFontSize))
+          .font(.notoSans(size: .defaultFontSize))
         
         Spacer()
         
@@ -341,16 +341,16 @@ extension AddSupplementView {
         } label: {
           RoundedRectangle(cornerRadius: 10)
             .fill(.backgroundGray)
-            .frame(width: 48, height: 36)
+            .frame(width: rectangleSize.width, height: rectangleSize.height)
             .overlay {
               Text("\(addSupplementVM.startMonth)")
-                .font(.notoSans(size: defaultFontSize))
+                .font(.notoSans(size: .defaultFontSize))
                 .foregroundStyle(.textGray)
             }
         }
         
         Text("월")
-          .font(.notoSans(weight: .regular, size: defaultFontSize))
+          .font(.notoSans(weight: .regular, size: .defaultFontSize))
           .padding(.trailing, 8)
         
         Button {
@@ -358,35 +358,35 @@ extension AddSupplementView {
         } label: {
           RoundedRectangle(cornerRadius: 10)
             .fill(.backgroundGray)
-            .frame(width: 48, height: 36)
+            .frame(width: rectangleSize.width, height: rectangleSize.height)
             .overlay {
               Text("\(addSupplementVM.startDay)")
-                .font(.notoSans(size: defaultFontSize))
+                .font(.notoSans(size: .defaultFontSize))
                 .foregroundStyle(.textGray)
             }
         }
         
         Text("일")
-          .font(.notoSans(weight: .regular, size: defaultFontSize))
+          .font(.notoSans(weight: .regular, size: .defaultFontSize))
       }
       
-      HStack(spacing: 8) {
+      HStack(spacing: .smallSpacing) {
         Text("복용 주기")
-          .font(.notoSans(size: defaultFontSize))
+          .font(.notoSans(size: .defaultFontSize))
         
         Spacer()
         
         RoundedRectangle(cornerRadius: 10)
           .fill(.backgroundGray)
-          .frame(width: 48, height: 36)
+          .frame(width: rectangleSize.width, height: rectangleSize.height)
           .overlay {
             Text("\(addSupplementVM.duration)")
-              .font(.notoSans(size: defaultFontSize))
+              .font(.notoSans(size: .defaultFontSize))
               .foregroundStyle(.textGray)
           }
         
         Text("일")
-          .font(.notoSans(weight: .regular, size: defaultFontSize))
+          .font(.notoSans(weight: .regular, size: .defaultFontSize))
       }
       .contentShape(Rectangle())
       .onTapGesture {
@@ -397,8 +397,12 @@ extension AddSupplementView {
   
   private func supplementCountSelector() -> some View {
     HStack {
+      let imageWidth: CGFloat = isPad ? 33 : 23
+      let iconSize: CGFloat = .defaultFontSize - 2
+      let textSize: CGFloat = .defaultFontSize + 2
+      
       Text("섭취 횟수")
-        .font(.notoSans(size: defaultFontSize))
+        .font(.notoSans(size: .defaultFontSize))
       
       Spacer()
       
@@ -407,28 +411,28 @@ extension AddSupplementView {
           addSupplementVM.removeRoutineTime()
         } label: {
           Circle()
-            .frame(width: 23, height: 23)
+            .frame(width: imageWidth, height: imageWidth)
             .foregroundStyle(.main)
             .overlay {
               Image(systemName: "minus")
-                .font(.system(size: 16, weight: .semibold))
+                .font(.system(size: iconSize, weight: .semibold))
                 .foregroundStyle(.white)
             }
         }
         
         Text("\(addSupplementVM.doseSchedules.count)")
-          .font(.notoSans(size: defaultFontSize))
+          .font(.notoSans(size: textSize))
           .padding(.bottom, 3)
         
         Button {
           addSupplementVM.addRoutineTime()
         } label: {
           Circle()
-            .frame(width: 23, height: 23)
+            .frame(width: imageWidth, height: imageWidth)
             .foregroundStyle(.main)
             .overlay {
               Image(systemName: "plus")
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: iconSize, weight: .semibold))
                 .foregroundStyle(.white)
             }
         }
@@ -438,8 +442,10 @@ extension AddSupplementView {
   
   private func timeSelectionSection() -> some View {
     VStack(alignment: .leading){
+      let circleWidth: CGFloat = isPad ? 25 : 18
+      
       Text("복용 시간")
-        .font(.notoSans(size: defaultFontSize))
+        .font(.notoSans(size: .defaultFontSize))
       
       ForEach(addSupplementVM.doseSchedules.indices, id: \.self) { index in
         let routine = addSupplementVM.doseSchedules[index]
@@ -448,22 +454,22 @@ extension AddSupplementView {
           ZStack {
             Circle()
               .fill(.main)
-              .frame(width: 18, height: 18)
+              .frame(width: circleWidth, height: circleWidth)
             
             Text("\(index + 1)")
-              .font(.notoSans(weight: .bold, size: 10))
+              .font(.notoSans(weight: .bold, size: .defaultFontSize - 8))
               .foregroundStyle(.white)
               .padding(.bottom, 1)
           }
           
           Text(routine.time.timeFormatter)
-            .font(.notoSans(weight: .regular, size: defaultFontSize))
+            .font(.notoSans(weight: .regular, size: .defaultFontSize))
             .padding(.bottom, 2)
           
           Spacer()
           
           Text(routine.doseString)
-            .font(.notoSans(weight: .regular, size: defaultFontSize))
+            .font(.notoSans(weight: .regular, size: .defaultFontSize))
             .foregroundStyle(.textGray)
             .padding(.bottom, 2)
         }
@@ -479,7 +485,6 @@ extension AddSupplementView {
   
   private func aiRecommendationSection() -> some View {
     AIRecommendedScheduleView(
-      defaultFontSize: defaultFontSize,
       supplementSummary: addSupplementVM.supplemtSummary,
       lifestyle: lifestyleTimeVM.userLifestyle,
       supplement: $addSupplementVM.supplement
@@ -489,7 +494,7 @@ extension AddSupplementView {
   private func memoSection() -> some View {
     VStack(alignment: .leading) {
       Text("메모")
-        .font(.notoSans(size: defaultFontSize))
+        .font(.notoSans(size: .defaultFontSize))
       
       InputTextField(
         text: $addSupplementVM.memo,
@@ -504,7 +509,7 @@ extension AddSupplementView {
       .padding(.horizontal, 4)
     }
     .cardStyle(padding: .defaultSpacing)
-    .frame(height: 95)
+    .frame(height: isPad ? 115 : 95)
   }
 }
 

--- a/Meditory/Meditory/Features/AddSupplement/View/AddSupplementView.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/AddSupplementView.swift
@@ -88,6 +88,8 @@ struct AddSupplementView: View {
 
   var body: some View {
     GeometryReader { scrollView in
+      let isLandscape = scrollView.size.width > scrollView.size.height
+      
       ZStack {
         ScrollViewReader { proxy in
           ScrollView {
@@ -101,6 +103,7 @@ struct AddSupplementView: View {
           }
           .scrollDismissesKeyboard(.immediately)
           .scrollIndicators(.hidden)
+          .frame(maxWidth: isLandscape ? scrollView.size.width * 0.7 : .infinity)
           .navigationBar(
             type == .add ? .addSupplement : .editSupplement,
             isAtTop: isAtTop

--- a/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimePickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimePickerSheet.swift
@@ -157,10 +157,10 @@ extension LifestyleTimePickerSheet {
   ) -> some View {
     VStack(spacing: .smallSpacing) {
       Text("\(type.title) 수정")
-        .font(.notoSans(weight: .semiBold, size: 20))
+        .font(.notoSans(weight: .semiBold, size: .defaultFontSize + 2))
       
       Text(type.subtitle)
-        .font(.notoSans(size: 14))
+        .font(.notoSans(size: .defaultFontSize - 4))
         .minimumScaleFactor(0.8)
         .foregroundStyle(.textGray)
     }
@@ -198,28 +198,28 @@ extension LifestyleTimePickerSheet {
           .frame(width: 25, height: 25)
         
         Text(title)
-          .font(.notoSans(size: 18))
+          .font(.notoSans(size: .defaultFontSize))
         
         Text(isMealSkipped(index: index) ? "안 함" : dates[index].timeFormatter)
-          .font(.notoSans(size: 18))
+          .font(.notoSans(size: .defaultFontSize))
           .foregroundStyle(.textGray)
         
         Spacer()
         
         Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
           .foregroundStyle(.textGray)
-          .font(.system(size: 18, weight: .medium))
+          .font(.system(size: .defaultFontSize, weight: .medium))
       }
       
       if isExpanded {
         if isMealType {
           HStack(alignment: .firstTextBaseline) {
             Text("식사 안 함")
-              .font(.notoSans(size: 16))
+              .font(.notoSans(size: .defaultFontSize - 2))
               .foregroundStyle(isMealSkipped(index: index) ? .label : Color.textGray)
             
             Image(systemName: "checkmark")
-              .font(.system(size: 14, weight: .bold))
+              .font(.system(size: .defaultFontSize - 4, weight: .bold))
               .foregroundStyle(isMealSkipped(index: index) ? .main : Color.textGray)
             
             Spacer()

--- a/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimePickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimePickerSheet.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct LifestyleTimePickerSheet: View {
   
+  @Environment(\.colorScheme) private var colorScheme
+  
   let type: LifestyleTimeType
   @State var option: any LifestyleTime
   @State var dates: [Date]
@@ -68,7 +70,9 @@ struct LifestyleTimePickerSheet: View {
           .background(
             GeometryReader { geometry in
               Rectangle()
-                .fill(.background)
+                .fill(
+                  colorScheme.isLightMode ? .white : Color.init(red: 36, green: 36, blue: 36)
+                )
                 .clipShape(
                   RoundedCorner(radius: 20, corners: [.topLeft, .topRight])
                 )
@@ -212,7 +216,7 @@ extension LifestyleTimePickerSheet {
           HStack(alignment: .firstTextBaseline) {
             Text("식사 안 함")
               .font(.notoSans(size: 16))
-              .foregroundStyle(isMealSkipped(index: index) ? .black : Color.textGray)
+              .foregroundStyle(isMealSkipped(index: index) ? .label : Color.textGray)
             
             Image(systemName: "checkmark")
               .font(.system(size: 14, weight: .bold))

--- a/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimePickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimePickerSheet.swift
@@ -27,6 +27,9 @@ struct LifestyleTimePickerSheet: View {
       ZStack {
         Rectangle()
           .fill(.black.opacity(0.3))
+          .onTapGesture {
+            dismissWithAnimation()
+          }
         
         VStack {
           Spacer()

--- a/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimeView.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/LifestyleTimeView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct LifestyleTimeView: View {
   
   let type: LifestyleTimeType
-  let defaultFontSize: CGFloat
   let lifestyleTimeItems: [LifestyleTimeItem]
   let onTapGesture: ((any LifestyleTime) -> Void)?
   
@@ -20,13 +19,13 @@ struct LifestyleTimeView: View {
     VStack(alignment: .leading) {
       HStack {
         Text(type.title)
-          .font(.notoSans(size: defaultFontSize))
+          .font(.notoSans(size: .defaultFontSize))
         
         Spacer()
         
         Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
           .foregroundStyle(.textGray)
-          .font(.system(size: defaultFontSize, weight: .medium))
+          .font(.system(size: .defaultFontSize, weight: .medium))
       }
       .contentShape(Rectangle())
       .onTapGesture {
@@ -65,13 +64,13 @@ extension LifestyleTimeView {
         .frame(width: 25, height: 25)
       
       Text(title)
-        .font(.notoSans(weight: .regular, size: defaultFontSize))
+        .font(.notoSans(weight: .regular, size: .defaultFontSize))
         .foregroundStyle(.textGray)
       
       Spacer()
       
       Text(time)
-        .font(.notoSans(weight: .regular, size: defaultFontSize))
+        .font(.notoSans(weight: .regular, size: .defaultFontSize))
     }
   }
 }

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/DayPickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/DayPickerSheet.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct DayPickerSheet: View {
   
   @State var selectedDay: Int
-  var days: [Int]
+  let days: [Int]
   var onDismiss: (Int?) -> Void
   
   var body: some View {
@@ -22,7 +22,7 @@ struct DayPickerSheet: View {
       Picker("Day", selection: $selectedDay) {
         ForEach(days, id: \.self) { day in
           Text("\(day)")
-            .font(.notoSans(size: 25))
+            .font(.notoSans(size: UIDevice.isPad ? 27 : 25))
         }
       }
       .pickerStyle(.wheel)

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/DurationPickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/DurationPickerSheet.swift
@@ -22,7 +22,7 @@ struct DurationPickerSheet: View {
       Picker("Duration", selection: $selectedDuration) {
         ForEach(1...30, id: \.self) { day in
           Text("\(day)")
-            .font(.notoSans(size: 25))
+            .font(.notoSans(size: UIDevice.isPad ? 27 : 25))
         }
       }
       .pickerStyle(.wheel)

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/MonthPickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/MonthPickerSheet.swift
@@ -21,7 +21,7 @@ struct MonthPickerSheet: View {
       Picker("Month", selection: $selectedMonth) {
         ForEach(1...12, id: \.self) { month in
           Text("\(month)")
-            .font(.notoSans(size: 25))
+            .font(.notoSans(size: UIDevice.isPad ? 27 : 25))
         }
       }
       .pickerStyle(.wheel)

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/SchedulePickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/SchedulePickerSheet.swift
@@ -9,7 +9,8 @@ import SwiftUI
 
 struct SchedulePickerSheet<Content: View>: View {
   
-  @Environment(\.dismiss) var dismiss
+  @Environment(\.colorScheme) private var colorScheme
+  @Environment(\.dismiss) private var dismiss
   
   private let title: String?
   private let needsAlert: Bool
@@ -89,7 +90,9 @@ struct SchedulePickerSheet<Content: View>: View {
           .background(
             GeometryReader { geometry in
               Rectangle()
-                .fill(.background)
+                .fill(
+                  colorScheme.isLightMode ? .white : Color.init(red: 36, green: 36, blue: 36)
+                )
                 .clipShape(
                   RoundedCorner(radius: 20, corners: [.topLeft, .topRight])
                 )

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/SchedulePickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/SchedulePickerSheet.swift
@@ -72,7 +72,12 @@ struct SchedulePickerSheet<Content: View>: View {
             
             if let title {
               Text(title)
-                .font(.notoSans(weight: .medium, size: 16))
+                .font(
+                  .notoSans(
+                    weight: .medium,
+                    size: .defaultFontSize - 2
+                  )
+                )
             }
             
             content

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/TimePickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/TimePickerSheet.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct TimePickerSheet: View {
   
+  private let isPad = UIDevice.isPad
+  
   @State var doseSchedule: SupplementDoseSchedule
   let selectedIndex: Int
   let doseSchedules: [SupplementDoseSchedule]
@@ -34,15 +36,19 @@ struct TimePickerSheet: View {
   
   private var doseSection: some View {
     HStack {
+      let imageWidth: CGFloat = isPad ? 33 : 23
+      let iconSize: CGFloat = .defaultFontSize - 2
+      let textSize: CGFloat = .defaultFontSize + 2
+      
       Button {
         doseSchedule.pillsPerDose = max(1, doseSchedule.pillsPerDose - 1)
       } label: {
         Circle()
-          .frame(width: 23, height: 23)
+          .frame(width: imageWidth, height: imageWidth)
           .foregroundStyle(.main)
           .overlay {
             Image(systemName: "minus")
-              .font(.system(size: 16, weight: .semibold))
+              .font(.system(size: iconSize, weight: .semibold))
               .foregroundStyle(.white)
           }
       }
@@ -50,7 +56,7 @@ struct TimePickerSheet: View {
       Spacer()
       
       Text("\(doseSchedule.pillsPerDose)")
-        .font(.notoSans(weight: .regular, size: 20))
+        .font(.notoSans(weight: .regular, size: textSize))
         .padding(.bottom, 3)
       
       Spacer()
@@ -59,11 +65,11 @@ struct TimePickerSheet: View {
         doseSchedule.pillsPerDose += 1
       } label: {
         Circle()
-          .frame(width: 23, height: 23)
+          .frame(width: imageWidth, height: imageWidth)
           .foregroundStyle(.main)
           .overlay {
             Image(systemName: "plus")
-              .font(.system(size: 14, weight: .semibold))
+              .font(.system(size: iconSize, weight: .semibold))
               .foregroundStyle(.white)
           }
       }
@@ -97,7 +103,7 @@ struct TimePickerSheet: View {
         .frame(height: 216)
         
         Text("섭취 량")
-          .font(.notoSans(weight: .medium, size: 16))
+          .font(.notoSans(size: isPad ? 20 : 16))
           .padding(.bottom, .smallSpacing)
         
         doseSection

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/WeekdayPickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/WeekdayPickerSheet.swift
@@ -22,13 +22,13 @@ struct WeekdayPickerSheet: View {
         ForEach(Weekday.allCases, id:\.self) { weekday in
           HStack {
             Text(weekday.title)
-              .font(.notoSans(size: 18))
+              .font(.notoSans(size: .defaultFontSize))
             
             Spacer()
             
             CircleCheck(
               isCompleted: weekdays[weekday] ?? false,
-              size: 25
+              size: UIDevice.isPad ? 30 : 25
             )
           }
           .padding(.horizontal, 2)

--- a/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/WeekdayPickerSheet.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SchedulePicker/WeekdayPickerSheet.swift
@@ -39,7 +39,7 @@ struct WeekdayPickerSheet: View {
         }
       }
       .padding(.horizontal, .smallSpacing)
-      .padding(.vertical, .defaultSpacing)
+      .padding(.vertical, .defaultSpacing * 2)
     }
   }
 }

--- a/Meditory/Meditory/Features/AddSupplement/View/SupplementInfoView.swift
+++ b/Meditory/Meditory/Features/AddSupplement/View/SupplementInfoView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct SupplementInfoView: View {
   
-  let defaultFontSize: CGFloat
-  // @ObservedObject를 제거하고 일반 변수로 변경합니다.
+  private let isPad = UIDevice.isPad
+  
   var addSupplementVM: AddSupplementViewModel
   @Binding var isSearchingSupplementSummary: Bool
   
@@ -20,7 +20,7 @@ struct SupplementInfoView: View {
         // 서버에서 해당 이름으로 영양제/약을 특정할 수 없는 경우
         VStack {
           Text("해당 영양제를 확인할 수 없어요.\n이름을 다시 입력해 주세요.")
-            .font(.notoSans(size: defaultFontSize - 3))
+            .font(.notoSans(size: .defaultFontSize - 3))
             .foregroundStyle(.textGray)
             .padding(.vertical, .defaultSpacing)
             .multilineTextAlignment(.center)
@@ -33,11 +33,11 @@ struct SupplementInfoView: View {
       } else {
         VStack(alignment: .leading, spacing: .smallSpacing) {
           Text(summary.name)
-            .font(.notoSans(size: defaultFontSize))
+            .font(.notoSans(size: .defaultFontSize))
             .frame(maxWidth: .infinity, alignment: .leading)
           
           Text(summary.description)
-            .font(.notoSans(size: defaultFontSize - 5))
+            .font(.notoSans(size: .defaultFontSize - 5))
             .foregroundStyle(.textGray)
             .lineLimit(nil)
             .fixedSize(horizontal: false, vertical: true)
@@ -50,16 +50,16 @@ struct SupplementInfoView: View {
     }
     
     if isSearchingSupplementSummary {
-      VStack(alignment: .leading, spacing: .smallSpacing) {
+      VStack(alignment: .leading, spacing: .smallSpacing + 2) {
         ShimmerView(widthRatio: 0.6)
-          .frame(height: 20)
+          .frame(height: isPad ? 23 : 20)
         
         VStack(spacing: .smallSpacing / 2) {
           ShimmerView(widthRatio: 0.8)
-            .frame(height: 15)
+            .frame(height: isPad ? 18 : 15)
           
           ShimmerView(widthRatio: 0.6)
-            .frame(height: 15)
+            .frame(height: isPad ? 18 : 15)
         }
       }
       .frame(maxWidth: .infinity)

--- a/Meditory/Meditory/Features/CalendarBackground/Components/CalendarWeeklyHeader.swift
+++ b/Meditory/Meditory/Features/CalendarBackground/Components/CalendarWeeklyHeader.swift
@@ -45,10 +45,18 @@ struct CalendarWeeklyHeader: View {
       UIScreen.main.bounds.width > UIScreen.main.bounds.height
   }
 
-  private var yearMonthFontSize: CGFloat { isPadStyle ? 22 : 20 }
-  private var chevronFontSize: CGFloat { isPadStyle ? 17 : 15 }
-  private var weekNameFontSize: CGFloat { isPadStyle ? 15 : 13 }
-  private var dateFontSize: CGFloat { isPadStyle ? 18 : 16 }
+  private var yearMonthFontSize: CGFloat { .defaultFontSize + 2 }
+  private var chevronFontSize: CGFloat { .defaultFontSize - 3 }
+  private var weekNameFontSize: CGFloat { .defaultFontSize - 5 }
+  private var dateFontSize: CGFloat { .defaultFontSize - 2 }
+  private var circleSize: CGSize {
+    let isPad = UIDevice.isPad
+    
+    return CGSize(
+      width: isPad ? 35 : 25,
+      height: isPad ? 35 : 25
+    )
+  }
 
   private var horizontalInset: CGFloat {
     let screenWidth = UIScreen.main.bounds.width
@@ -115,12 +123,12 @@ struct CalendarWeeklyHeader: View {
             if selected {
               Circle()
                 .fill(.white)
-                .frame(width: 25, height: 25)
+                .frame(width: circleSize.width, height: circleSize.height)
                 .matchedGeometryEffect(id: "backgroundCircle", in: namespace)
             } else if today {
               Circle()
                 .fill(.white)
-                .frame(width: 25, height: 25)
+                .frame(width: circleSize.width, height: circleSize.height)
                 .opacity(0.3) // 오늘(비선택) 흐린 원
             }
 

--- a/Meditory/Meditory/Features/Common/InfoButton.swift
+++ b/Meditory/Meditory/Features/Common/InfoButton.swift
@@ -40,7 +40,7 @@ struct InfoButton: View {
         VStack {
           Text(message)
             .multilineTextAlignment(.center)
-            .font(.notoSans(size: 12))
+            .font(.notoSans(size: .defaultFontSize - 6))
             .foregroundStyle(.textGray)
             .lineLimit(nil)
             .fixedSize(horizontal: false, vertical: true)

--- a/Meditory/Meditory/Features/Common/NavigationBar/PrimaryNavigationBar.swift
+++ b/Meditory/Meditory/Features/Common/NavigationBar/PrimaryNavigationBar.swift
@@ -23,6 +23,7 @@ struct PrimaryNavigationBar: View {
   
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.dismiss) private var dismiss
+  private let isPad = UIDevice.isPad
   
   var title: NavigationTitle = .none
   var backgroundStyle: BackgroundStyle = .custom
@@ -31,7 +32,6 @@ struct PrimaryNavigationBar: View {
   
   private var navigationBar: some View {
     ZStack{
-      let isPad = UIDevice.isPad
       let fontSize: CGFloat = isPad ? 20 : 18
       
       Text(title.text)
@@ -53,8 +53,8 @@ struct PrimaryNavigationBar: View {
         Spacer()
       }
     }
-    .padding(.horizontal, 16)
-    .padding(.vertical, 12)
+    .padding(.horizontal, isPad ? .defaultSpacing + 3 : .defaultSpacing)
+    .padding(.vertical, isPad ? 15 : 12)
     .background(backgroundStyle.color)
     .dismissKeyboardOnTap()
   }

--- a/Meditory/Meditory/Features/Common/PrimaryButton.swift
+++ b/Meditory/Meditory/Features/Common/PrimaryButton.swift
@@ -20,10 +20,10 @@ struct PrimaryButton: View {
     } label: {
       RoundedRectangle(cornerRadius: 10)
         .fill(isSub ? Color.init(red: 229, green: 242, blue: 255) : (isEnabled ? .main : .gray.opacity(0.4)))
-        .frame(height: 50)
+        .frame(height: isPad ? 60 : 50)
         .overlay {
           Text(title)
-            .font(.notoSans(weight: .semiBold, size: isPad ? 28 : 18))
+            .font(.notoSans(weight: .semiBold, size: .defaultFontSize))
             .foregroundStyle(isSub ? .main : .white)
         }
     }

--- a/Meditory/Meditory/Features/DailyNutrition/View/AdvancedTopTabBarView.swift
+++ b/Meditory/Meditory/Features/DailyNutrition/View/AdvancedTopTabBarView.swift
@@ -31,7 +31,7 @@ struct AdvancedTopTabBarView: View {
             } label: {
               Text(tabs[index])
                 .font(.notoSans(weight: selectedTab == index ? .semiBold : .regular,
-                                size: 16))
+                                size: .defaultFontSize - 2))
                 .foregroundStyle(selectedTab == index ? .primary : .secondary)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
@@ -73,14 +73,14 @@ struct AdvancedTopTabBarView: View {
       
       HStack {
         Text("찾는 음식이 없나요?")
-          .font(.notoSans(weight: .semiBold, size: 18))
+          .font(.notoSans(weight: .semiBold, size: .defaultFontSize))
         
         Button {
           navigationManager.navigateTo(.addFood)
           
         } label: {
           Text("음식 직접 추가하기")
-            .font(.notoSans(weight: .bold, size: 19))
+            .font(.notoSans(weight: .bold, size: .defaultFontSize + 1))
             .foregroundStyle(.accent)
         }
       }

--- a/Meditory/Meditory/Features/DailyNutrition/View/FoodInputView.swift
+++ b/Meditory/Meditory/Features/DailyNutrition/View/FoodInputView.swift
@@ -78,7 +78,7 @@ struct FoodInputView: View {
         Spacer()
         
         Text(navigationTitle)
-          .font(.notoSans(weight: .semiBold, size: 18))
+          .font(.notoSans(weight: .semiBold, size: .defaultFontSize))
         
         Spacer()
         
@@ -87,7 +87,7 @@ struct FoodInputView: View {
             showingDeleteAlert = true
           } label: {
             Text("삭제")
-              .font(.notoSans(weight: .semiBold, size: 17))
+              .font(.notoSans(weight: .semiBold, size: .defaultFontSize - 1))
               .foregroundStyle(.red)
           }
         } else {
@@ -139,7 +139,7 @@ struct FoodInputView: View {
         .padding(.horizontal, 16)
         
         Text("AI 생성 영양정보로 실제 값과 다를 수 있습니다. 건강 관련 중요한 결정은 의료 전문가와 상의하세요.")
-          .font(.notoSans(weight: .medium, size: 7))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize - 8))
             .foregroundColor(.secondary)
             .multilineTextAlignment(.center)
       }
@@ -151,7 +151,7 @@ struct FoodInputView: View {
           Text("Tip‼️")
           
           Text(tipComment)
-            .font(.notoSans(weight: .medium, size: 12))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 6))
             .multilineTextAlignment(.leading)
             .lineLimit(nil)
         }
@@ -209,7 +209,7 @@ struct FoodInputView: View {
             .font(.notoSans(size: 50))
           
           Text(type.displayName)
-            .font(.notoSans(weight: .medium, size: 13))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 5))
             .foregroundStyle(.secondary)
           
           HStack(spacing: 5) {
@@ -229,7 +229,7 @@ struct FoodInputView: View {
               .frame(width: 10)
               .foregroundStyle(Color.label)
           }
-          .font(.notoSans(weight: .medium, size: 13))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize - 5))
         }
         .frame(maxWidth: .infinity)
       }

--- a/Meditory/Meditory/Features/DailyNutrition/View/MealDetailMainView.swift
+++ b/Meditory/Meditory/Features/DailyNutrition/View/MealDetailMainView.swift
@@ -52,14 +52,14 @@ struct MealDetailMainView: View {
       ForEach(macro.macroItems) { item in
         VStack {
           Text(item.label.prefix(1))
-            .font(.notoSans(weight: .bold, size: 18))
+            .font(.notoSans(weight: .bold, size: .defaultFontSize))
           
           Circle()
             .fill(item.color)
             .frame(width: 20, height: 20)
           
           Text("\(Int(item.gram))%")
-            .font(.notoSans(weight: .medium, size: 17))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 1))
         }
       }
     }

--- a/Meditory/Meditory/Features/DailyNutrition/component/DailyMealSummaryCard.swift
+++ b/Meditory/Meditory/Features/DailyNutrition/component/DailyMealSummaryCard.swift
@@ -22,7 +22,7 @@ struct DailyMealSummaryCard: View {
         VStack(spacing: 16) {
           HStack {
             Text("오늘 하루 식단")
-              .font(.notoSans(weight: .bold, size: 15))
+              .font(.notoSans(size: .defaultFontSize + 2))
               .foregroundStyle(Color.label)
             
             Spacer()
@@ -53,10 +53,10 @@ struct DailyMealSummaryCard: View {
             .frame(width: 14, height: 14)
           
             Text(item.label.prefix(1))
-              .font(.notoSans(weight: .regular, size: 13))
+              .font(.notoSans(weight: .regular, size: .defaultFontSize - 5))
             
             Text("\(Int(gram))%")
-              .font(.notoSans(weight: .semiBold, size: 13))
+              .font(.notoSans(weight: .semiBold, size: .defaultFontSize - 5))
         }
         .foregroundStyle(Color.label)
       }

--- a/Meditory/Meditory/Features/DailyNutrition/component/FoodGridView.swift
+++ b/Meditory/Meditory/Features/DailyNutrition/component/FoodGridView.swift
@@ -36,10 +36,10 @@ struct FoodGridView: View {
       
       HStack {
         Text(food.name)
-          .font(.notoSans(weight: .medium, size: 16))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize - 2))
         
         Text("\(Int(food.weight))g")
-          .font(.notoSans(weight: .regular, size: 15))
+          .font(.notoSans(weight: .regular, size: .defaultFontSize - 3))
       }
       .padding(.horizontal, 8)
       .lineLimit(1)

--- a/Meditory/Meditory/Features/DailyNutrition/component/MealSummaryCard.swift
+++ b/Meditory/Meditory/Features/DailyNutrition/component/MealSummaryCard.swift
@@ -37,7 +37,7 @@ struct MealSummaryCard: View {
       HStack {
         VStack(alignment: .leading, spacing: 16) {
           Text(food.name)
-            .font(.notoSans(weight: .bold, size: 15))
+            .font(.notoSans(weight: .bold, size: .defaultFontSize - 3))
           
           HStack(spacing: 40) {
             ForEach(food.macros.macroItems) { item in
@@ -48,10 +48,10 @@ struct MealSummaryCard: View {
                 
                 
                 Text(item.label)
-                  .font(.notoSans(weight: .regular, size: 12))
+                  .font(.notoSans(weight: .regular, size: .defaultFontSize - 6))
                 
                 Text("\(Int(item.gram))g")
-                  .font(.notoSans(weight: .semiBold, size: 12))
+                  .font(.notoSans(weight: .semiBold, size: .defaultFontSize - 6))
               }
               .frame(maxWidth: .infinity, alignment: .leading)
             }

--- a/Meditory/Meditory/Features/DailyNutrition/component/RecommendedMacroGuidePopover.swift
+++ b/Meditory/Meditory/Features/DailyNutrition/component/RecommendedMacroGuidePopover.swift
@@ -27,12 +27,13 @@ struct RecommendedMacroGuidePopover: View {
       
       VStack(alignment: .leading, spacing: 5) {
         Text("오늘 섭취 권장량")
-          .font(.notoSans(weight: .semiBold, size: 15))
+          .font(.notoSans(weight: .semiBold, size: .defaultFontSize - 3))
         
         macroPercentageView()
       }
       .foregroundStyle(.black)
-      .padding(.horizontal, 16)
+      .padding(.vertical, UIDevice.isPad ? .smallSpacing : .zero)
+      .padding(.horizontal, .defaultSpacing)
     }
   }
   
@@ -45,12 +46,12 @@ struct RecommendedMacroGuidePopover: View {
             .frame(width: 10, height: 10)
           
             Text(item.label)
-              .font(.notoSans(weight: .regular, size: 13))
+              .font(.notoSans(weight: .regular, size: .defaultFontSize - 5))
             
             Spacer()
             
             Text("\(Int(item.gram))g")
-              .font(.notoSans(weight: .semiBold, size: 11))
+              .font(.notoSans(weight: .semiBold, size: .defaultFontSize - 7))
         }
       }
     }

--- a/Meditory/Meditory/Features/Home/View/HomeView.swift
+++ b/Meditory/Meditory/Features/Home/View/HomeView.swift
@@ -58,7 +58,7 @@ private struct AchievementSection: View {
   var body: some View {
     UnifiedSectionCard(showsStroke: false) {
       Text("오늘 복용 달성률")
-        .font(.notoSans(size: 20))
+        .font(.notoSans(size: .defaultFontSize + 2))
         .frame(maxWidth: .infinity, alignment: .leading)
       if isPadStyle {
         VStack(spacing: 24) {
@@ -155,13 +155,13 @@ private struct AchievementSection: View {
           NavigationLink(destination: SupplementDetailView(routine: item.routine)) {
             HStack(spacing: .defaultSpacing) {
               Text(item.name)
-                .font(.notoSans(size: 18))
+                .font(.notoSans(size: .defaultFontSize))
                 .foregroundColor(.primary)
 
               Spacer()
 
               Text(item.time.timeFormatter)
-                .font(.notoSans(size: 15))
+                .font(.notoSans(size: .defaultFontSize - 3))
                 .foregroundStyle(
                   colorScheme == .dark ? Color.secondary : Color.main
                 )

--- a/Meditory/Meditory/Features/Home/View/TodayHealthView.swift
+++ b/Meditory/Meditory/Features/Home/View/TodayHealthView.swift
@@ -18,7 +18,7 @@ struct TodayHealthView: View {
       VStack(alignment: .leading, spacing: .smallSpacing) {
         HStack {
           Text("오늘의 건강 상식")
-            .font(.notoSans(size: 18))
+            .font(.notoSans(size: .defaultFontSize))
             .padding(.bottom, .smallSpacing)
           
           Spacer()
@@ -38,7 +38,7 @@ struct TodayHealthView: View {
             .padding(.top, 2)
           } else {
             Text(vm.healthContent)
-              .font(.notoSans(size: 15))
+              .font(.notoSans(size: .defaultFontSize - 3))
               .foregroundStyle(.secondary)
               .transition(.opacity)
           }

--- a/Meditory/Meditory/Features/MainTab/MainTabView.swift
+++ b/Meditory/Meditory/Features/MainTab/MainTabView.swift
@@ -27,8 +27,6 @@ struct MainTabView: View {
         } else {
           mainTabPhoneView()
         }
-        
-        intakeDestinationView()
       }
 
       // 추후 적용 예정
@@ -64,7 +62,7 @@ extension MainTabView {
         right: .defaultSpacing * 2
       )
       
-      if selectedTabItem == .home {
+      if selectedTabItem == .home || selectedTabItem == .dailyNutrition {
         VStack(spacing: .zero) {
           Spacer()
           
@@ -130,17 +128,5 @@ extension MainTabView {
       }
     }
     .ignoresSafeArea(edges: .bottom)
-  }
-  
-  @ViewBuilder
-  private func intakeDestinationView() -> some View {
-    if !showIntakeSelector, let intakeItem = selectedIntakeItem {
-      switch intakeItem {
-      case .supplement:
-        AddSupplementView(selectedIntakeItem: $selectedIntakeItem)
-      case .meal:
-        FoodInputView()
-      }
-    }
   }
 }

--- a/Meditory/Meditory/Features/Onboarding/Components/CapsuleShappedText.swift
+++ b/Meditory/Meditory/Features/Onboarding/Components/CapsuleShappedText.swift
@@ -14,7 +14,7 @@ struct CapsuleShappedText: View {
 
   var body: some View {
     Text("\(title)")
-      .adaptiveFont(isPad ? 20 : 15,weight: .medium)
+      .adaptiveFont(.defaultFontSize - 3,weight: .medium)
       .foregroundStyle(isSelected ? Color.white: .sub)
       .padding(.horizontal, 12)
       .padding(.vertical, 6)

--- a/Meditory/Meditory/Features/Onboarding/Components/CollectionItemCell.swift
+++ b/Meditory/Meditory/Features/Onboarding/Components/CollectionItemCell.swift
@@ -18,7 +18,7 @@ struct CollectionItemCell: View {
         RoundedRectangle(cornerRadius: .defaultSpacing)
           .stroke(Color.gray.opacity(0.3), lineWidth: isSelected ? 0 : 1)
           .fill(isSelected ? Color.sub.opacity(0.14) : Color.clear)
-          .adaptiveImage(isPad ? 150 : 100)
+          .adaptiveImage(isPad ? 130 : 100)
           .foregroundStyle(.sub.opacity(0.14))
           .zIndex(0)
         Image(model.image)
@@ -31,7 +31,7 @@ struct CollectionItemCell: View {
       }
       .modifier(UnifiedShadow())
       Text(model.title)
-        .adaptiveFont(isPad ? 22 : 14,weight: .medium)
+        .adaptiveFont(.defaultFontSize - 4,weight: .medium)
         .foregroundStyle(isSelected ? Color.label : .textGray)
     }
     .adaptiveImage(isPad ? 190 : 140)

--- a/Meditory/Meditory/Features/Onboarding/Components/ImageWithTitle.swift
+++ b/Meditory/Meditory/Features/Onboarding/Components/ImageWithTitle.swift
@@ -29,7 +29,7 @@ struct ImageWithTitle: View {
           onAction?()
         }
       Text(gender.title)
-        .adaptiveFont(isPad ? 28 : 18,small: -6,weight: .medium)
+        .adaptiveFont(.defaultFontSize,small: -6,weight: .medium)
         .foregroundStyle(isSelected ? Color.label : .textGray)
         .adaptivePadding(.bottom,isPad ? 0 : 4, small: isPad ? 0 : -4)
     }

--- a/Meditory/Meditory/Features/Onboarding/Components/RowItemCell.swift
+++ b/Meditory/Meditory/Features/Onboarding/Components/RowItemCell.swift
@@ -28,10 +28,10 @@ struct RowItemCell: View {
           .alignmentGuide(.top) { d in d[.top] - 4 }
         VStack(alignment: .leading, spacing: 2) {
           Text(model.title)
-            .adaptiveFont(isPad ? 22 : 14,weight: .medium)
+            .adaptiveFont(.defaultFontSize - 4,weight: .medium)
             .foregroundStyle(isSelected ? Color.label : .textGray)
           Text(model.subtitle)
-            .adaptiveFont(isPad ? 20 : 12,weight: .regular)
+            .adaptiveFont(.defaultFontSize - 6,weight: .regular)
             .foregroundStyle(.textGray)
         }
         Spacer()

--- a/Meditory/Meditory/Features/Onboarding/Components/TextInputView.swift
+++ b/Meditory/Meditory/Features/Onboarding/Components/TextInputView.swift
@@ -49,20 +49,20 @@ struct TextInputView: View {
     VStack(alignment: .leading) {
       HStack {
         Text(title)
-          .adaptiveFont(isPad ? 24 : 14,weight: .medium)
+          .adaptiveFont(.defaultFontSize - 4,weight: .medium)
           .foregroundStyle(.gray)
         if let error = errorMessage {
           Spacer()
           Text(error)
             .foregroundStyle(.red)
-            .adaptiveFont(isPad ? 22 : 12,weight: .medium)
+            .adaptiveFont(.defaultFontSize - 6,weight: .medium)
         }
       }
       HStack {
         NoQuickTypeTextField(text: $inputText, placeholder: placeholder, keyboardType: keyboardType,onSubmit: {
           onAction?()
         })
-        .adaptiveFont(isPad ? 24 : 14,weight: .semiBold)
+        .adaptiveFont(.defaultFontSize - 4,weight: .semiBold)
           .padding(.horizontal)
           .frame(height: 60)
           .background(
@@ -73,7 +73,7 @@ struct TextInputView: View {
             if let unit = unit {
               Text(unit)
                 .padding(.trailing, isPad ? 12 : 8)
-                .adaptiveFont(isPad ? 20 : 12,weight: .bold)
+                .adaptiveFont(.defaultFontSize - 3, weight: .bold)
                 .foregroundStyle(Color.textGray)
                 .padding(.trailing, .smallSpacing)
             }

--- a/Meditory/Meditory/Features/Onboarding/Components/TitleView.swift
+++ b/Meditory/Meditory/Features/Onboarding/Components/TitleView.swift
@@ -16,12 +16,12 @@ struct TitleView: View {
     HStack {
       VStack(alignment: .leading) {
         Text(prompt.title(name: name))
-          .adaptiveFont(isPad ?  40 : 26,small: -8,weight: .bold)
+          .adaptiveFont(isPad ? 40 : 26,small: -8,weight: .bold)
           .padding(.vertical, 10)
           .fixedSize()
         if let secondary = prompt.info(context: extra) ?? prompt.subtitle {
           Text(secondary)
-            .adaptiveFont(isPad ? 26 : 16 ,weight: .medium)
+            .adaptiveFont(.defaultFontSize - 2 ,weight: .medium)
             .foregroundStyle(.textGray)
         }
       }

--- a/Meditory/Meditory/Features/Onboarding/Model/Prompt.swift
+++ b/Meditory/Meditory/Features/Onboarding/Model/Prompt.swift
@@ -32,7 +32,7 @@ struct Prompt {
 
   static let promptMessage: [Step: Prompt] = [
     .base: Prompt(title: "나만의 맞춤 영양 설정\n1분이면 끝나요"),
-    .gender: Prompt(title: "님의\n성별을 알려주세요", subtitle: "성별", info: "아래에 해당하는 상태가 있다면 선택해주세요."),
+    .gender: Prompt(title: "님의\n성별을 알려주세요", subtitle: "성별", info: ""),
     .allergy: Prompt(title: "님이 갖고 있는 식품관련\n알레르기를 모두 알려주세요", info: "알레르기에 따라\n피해야하는 영양성분을 확인할 수 있어요"),
     .disease: Prompt(title: "님이 갖고 있는 질환을\n모두 알려주세요", info: "해당 되는 질병을 모두 골라주세요"),
     .concern: Prompt(title: "고민되시거나 개선하고\n싶은 건강 고민을 선택해주세요", info:"개의 고민이 선택되었습니다."),

--- a/Meditory/Meditory/Features/Onboarding/View/OnboardingGenderView.swift
+++ b/Meditory/Meditory/Features/Onboarding/View/OnboardingGenderView.swift
@@ -40,7 +40,7 @@ struct OnboardingGenderView: View {
     VStack(alignment: .leading, spacing: .defaultSpacing) {
       if let info = prompt.info {
         Text(info)
-          .adaptiveFont(isPad ? 26 : 16,small: -4,weight: .medium)
+          .adaptiveFont(.defaultFontSize - 2 ,weight: .medium)
           .foregroundStyle(.textGray)
           .padding(.bottom,.defaultSpacing)
       }

--- a/Meditory/Meditory/Features/Onboarding/View/OnboardingGenderView.swift
+++ b/Meditory/Meditory/Features/Onboarding/View/OnboardingGenderView.swift
@@ -39,7 +39,7 @@ struct OnboardingGenderView: View {
     .adaptivePadding(.bottom, 20,small: -10)
     VStack(alignment: .leading, spacing: .defaultSpacing) {
       if let info = prompt.info {
-        Text(info)
+        Text("아래에 해당하는 상태가 있다면 선택해주세요.")
           .adaptiveFont(.defaultFontSize - 2 ,weight: .medium)
           .foregroundStyle(.textGray)
           .padding(.bottom,.defaultSpacing)

--- a/Meditory/Meditory/Features/Onboarding/View/OnboardingView.swift
+++ b/Meditory/Meditory/Features/Onboarding/View/OnboardingView.swift
@@ -147,14 +147,20 @@ struct OnboardingView: View {
 
   @ViewBuilder
   func progressIndicator() -> some View {
-    let columns: [GridItem] = Array(repeating: GridItem(.flexible()), count: Step.totalCount)
+    let columns: [GridItem] = Array(
+      repeating: GridItem(
+        .flexible(),
+        spacing: isPad ? 20 : .smallSpacing
+      ),
+      count: Step.totalCount
+    )
     HStack {
       LazyVGrid(columns: columns) {
         ForEach(Step.allCases, id: \.self) { index in
           Text(String(index.rawValue + 1))
-            .font(.notoSans(size: 13))
+            .font(.notoSans(size: .defaultFontSize - 5))
             .foregroundStyle(index == currentStep ? Color.white : Color.gray)
-            .frame(width: 25, height: 25)
+            .frame(width: isPad ? 30 : 25, height: isPad ? 30 : 25)
             .background {
               Circle()
                 .fill(index == currentStep ? Color.main : Color.gray.opacity(0.2))

--- a/Meditory/Meditory/Features/Recommend/Components/ProductTile.swift
+++ b/Meditory/Meditory/Features/Recommend/Components/ProductTile.swift
@@ -52,13 +52,13 @@ struct ProductTile: View {
           if imageLoaded {
             Text(product.brand)
               .padding(.leading, 2)
-              .font(.notoSans(weight: .medium, size: 13))
+              .font(.notoSans(weight: .medium, size: .defaultFontSize - 5))
               .foregroundStyle(.gray)
               .frame(width: 110, height: 16, alignment: .topLeading)
 
             Text(product.name)
               .padding(.leading, 2)
-              .font(.notoSans(weight: .medium, size: 12))
+              .font(.notoSans(weight: .medium, size: .defaultFontSize - 6))
               .lineLimit(2)
               .multilineTextAlignment(.leading)
               .frame(width: 110, height: 40, alignment: .topLeading)

--- a/Meditory/Meditory/Features/Recommend/View/AnalysisView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/AnalysisView.swift
@@ -92,7 +92,7 @@ private struct SectionChipsParagraphView: View {
   var body: some View {
     VStack(alignment: .leading, spacing: .defaultSpacing) {
       Text(title)
-        .font(.notoSans(weight: .bold, size: 18))
+        .font(.notoSans(weight: .bold, size: .defaultFontSize))
         .foregroundColor(titleColor)
 
       // 칩을 가로 스크롤로 나열
@@ -106,7 +106,7 @@ private struct SectionChipsParagraphView: View {
 
       // 설명 문단
       Text(paragraph)
-        .font(.notoSans(weight: .medium, size: 15))
+        .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
         .lineSpacing(4)
     }
   }

--- a/Meditory/Meditory/Features/Recommend/View/ImageCardView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/ImageCardView.swift
@@ -40,14 +40,14 @@ struct ImageCardView: View {
     VStack(alignment: .leading, spacing: 12) {
       HStack {
         Text(title)
-          .font(.notoSans(weight: .medium, size: 18))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize))
         Spacer()
 
         Button {
           showConcernEdit = true
         } label: {
           Text("수정하기")
-            .font(.notoSans(weight: .medium, size: 12))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 6))
         }
       }
 
@@ -85,7 +85,7 @@ struct ImageCardView: View {
       }
 
       Text(desc)
-        .font(.notoSans(weight: .medium, size: 12))
+        .font(.notoSans(weight: .medium, size: .defaultFontSize - 6))
         .foregroundColor(.gray)
 
       ScrollViewReader { proxy in

--- a/Meditory/Meditory/Features/Recommend/View/NutrientCardView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/NutrientCardView.swift
@@ -5,7 +5,7 @@ struct NutrientChip: View {
 
   var body: some View {
     Text("💊 \(title)")
-      .font(.notoSans(weight: .medium, size: 15))
+      .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
       .padding(.horizontal, 12)
       .padding(.vertical, 6)
       .overlay {
@@ -31,7 +31,7 @@ struct NutrientCardView: View {
     VStack(alignment: .leading, spacing: .defaultSpacing) {
       HStack {
         Text("\(safeName) 님 맞춤 영양소 추천")
-          .font(.notoSans(weight: .medium, size: 18))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize))
 
         Spacer()
 
@@ -45,7 +45,7 @@ struct NutrientCardView: View {
       }
 
       Text("식단을 분석해 \(safeName) 님께 부족한 영양소를 추천드려요.")
-        .font(.notoSans(weight: .medium, size: 12))
+        .font(.notoSans(weight: .medium, size: .defaultFontSize - 6))
         .foregroundColor(.gray)
 
       FlowLayout(spacing: .smallSpacing, lineSpacing: .smallSpacing) {

--- a/Meditory/Meditory/Features/Recommend/View/NutrientDetailSectionView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/NutrientDetailSectionView.swift
@@ -89,17 +89,17 @@ struct NutrientDetailSectionView: View {
         HStack {
           ForEach(nutrient.hashtags, id: \.self) { tag in
             Text("# \(tag)")
-              .font(.notoSans(weight: .medium, size: 15))
+              .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
               .foregroundColor(.main)
           }
         }
 
         Text(nutrient.title)
-          .font(.notoSans(weight: .regular, size: 15))
+          .font(.notoSans(weight: .regular, size: .defaultFontSize - 3))
           .padding(.vertical, 8)
 
         Text(nutrient.content)
-          .font(.notoSans(weight: .regular, size: 15))
+          .font(.notoSans(weight: .regular, size: .defaultFontSize - 3))
           .foregroundColor(.secondary)
       }
       .padding(.vertical)

--- a/Meditory/Meditory/Features/Recommend/View/ProductCardView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/ProductCardView.swift
@@ -12,17 +12,17 @@ struct ProductCardView: View {
         .cornerRadius(.smallRadius)
 
       Text(product.brand)
-        .font(.notoSans(weight: .medium, size: 15))
+        .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
         .foregroundColor(.gray)
 
       Text(product.name)
-        .font(.notoSans(weight: .medium, size: 15))
+        .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
         .lineLimit(2)
 
       HStack(spacing: .smallSpacing) {
         Image(systemName: "star.fill")
           .foregroundColor(.yellow)
-          .font(.notoSans(weight: .medium, size: 15))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
       }
     }
     .frame(width: 120)

--- a/Meditory/Meditory/Features/Recommend/View/RecommendNutrientsView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/RecommendNutrientsView.swift
@@ -23,19 +23,19 @@ struct RecommendNutrientsView: View {
       VStack(alignment: .leading) {
         VStack(alignment: .leading, spacing: .smallSpacing) {
           Text("최종결과")
-            .font(.notoSans(weight: .medium, size: 15))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
             .foregroundColor(.gray)
 
           Text("\(safeName) 님의")
-            .font(.notoSans(weight: .bold, size: 25))
+            .font(.notoSans(weight: .bold, size: .defaultFontSize + 7))
             .fontWeight(.bold)
 
           Text("식단을 고려한 추천하는 영양성분이에요.")
-            .font(.notoSans(weight: .medium, size: 15))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
             .fontWeight(.semibold)
 
           Text("* 본 결과는 의사의 처방을 대신하지 않습니다.")
-            .font(.notoSans(weight: .medium, size: 15))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
             .foregroundColor(.gray)
         }
         .padding(.horizontal, 16)
@@ -45,12 +45,12 @@ struct RecommendNutrientsView: View {
         VStack(alignment: .leading, spacing: .defaultSpacing) {
           HStack {
             Text("🤟🏻 추천 영양성분")
-              .font(.notoSans(weight: .bold, size: 15))
+              .font(.notoSans(weight: .bold, size: .defaultFontSize - 3))
               .fontWeight(.bold)
 
 
             Text("3")
-              .font(.notoSans(weight: .bold, size: 15))
+              .font(.notoSans(weight: .bold, size: .defaultFontSize - 3))
               .fontWeight(.bold)
               .foregroundColor(.main)
           }
@@ -66,7 +66,7 @@ struct RecommendNutrientsView: View {
               .cornerRadius(.smallRadius)
 
             Text("추천하는 영양성분은 꼭 필요한 것만 추천되므로 아래 성분들을 모두 섭취하는것이 좋아요.")
-              .font(.notoSans(weight: .medium, size: 15))
+              .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
               .foregroundColor(Color.main)
               .multilineTextAlignment(.leading)
 

--- a/Meditory/Meditory/Features/Recommend/View/RecommendView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/RecommendView.swift
@@ -150,7 +150,7 @@ struct RecommendView: View {
                 HStack {
                   Text(searchText.isEmpty ? "영양성분 또는 영양제를 검색해보세요!" : searchText)
                     .foregroundColor(searchText.isEmpty ? .gray : .black)
-                    .font(.notoSans(weight: .medium, size: 15))
+                    .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                   Image(systemName: "magnifyingglass")
@@ -175,7 +175,7 @@ struct RecommendView: View {
                 VStack {
                   Text("추천")
                     .foregroundColor(selectedScene == .recommend ? .white : Color.white.opacity(0.5))
-                    .font(.notoSans(weight: .bold, size: 16))
+                    .font(.notoSans(weight: .bold, size: .defaultFontSize - 2))
                 }
               }
               .padding(.trailing, 16)
@@ -186,7 +186,7 @@ struct RecommendView: View {
                 VStack {
                   Text("스크랩")
                     .foregroundColor(selectedScene == .scrap ? .white : Color.white.opacity(0.5))
-                    .font(.notoSans(weight: .bold, size: 16))
+                    .font(.notoSans(weight: .bold, size: .defaultFontSize - 2))
                 }
               }
             }
@@ -306,7 +306,7 @@ struct RecommendView: View {
           }
         }
       )
-      .font(.notoSans(weight: .medium, size: 15))
+      .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
       .modifier(UnifiedShadow())
       .padding(.horizontal, 16)
 

--- a/Meditory/Meditory/Features/Recommend/View/ScoreDetailView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/ScoreDetailView.swift
@@ -24,7 +24,7 @@ struct ScoreDetailView: View {
 
           VStack(spacing: .defaultSpacing) {
             Text("AI 분석결과")
-              .font(.notoSans(weight: .bold, size: 15))
+              .font(.notoSans(weight: .bold, size: .defaultFontSize - 3))
               .foregroundColor(Color.accent)
               .padding(.top, 16)
 
@@ -40,7 +40,7 @@ struct ScoreDetailView: View {
 
             NavigationLink(destination: AnalysisView(result: result)) {
               Text("성분 분석 전체 보기")
-                .font(.notoSans(weight: .medium, size: 15))
+                .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
                 .foregroundColor(colorScheme == .dark ? Color.white : Color.black)
                 .padding(16)
                 .frame(maxWidth: .infinity)
@@ -99,7 +99,7 @@ private struct HeaderBar: View {
 
       HStack {
         Text("영양제 분석 리포트")
-          .font(.notoSans(weight: .bold, size: 25))
+          .font(.notoSans(weight: .bold, size: .defaultFontSize + 7))
           .foregroundColor(.white)
 
         Spacer()
@@ -148,7 +148,7 @@ private struct ScoreGauge: View {
         Text("\(score)")
           .font(.notoSans(weight: .medium, size: 50))
         Text("점")
-          .font(.notoSans(weight: .medium, size: 20))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize + 2))
       }
     }
     .padding(.vertical, 16)
@@ -179,7 +179,7 @@ private struct StatRow: View {
     var body: some View {
       HStack {
         Text(item.title)
-          .font(.notoSans(weight: .bold, size: 12))
+          .font(.notoSans(weight: .bold, size: .defaultFontSize - 6))
           .foregroundColor(item.tint)
           .padding(.horizontal, 8)
           .padding(.vertical, 4)
@@ -193,7 +193,7 @@ private struct StatRow: View {
         Spacer()
 
         Text("\(item.count) 개")
-          .font(.notoSans(weight: .medium, size: 12))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize - 6))
       }
       .padding(16)
       .background(

--- a/Meditory/Meditory/Features/Recommend/View/ScoreView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/ScoreView.swift
@@ -51,7 +51,7 @@ struct ScoreView: View {
     VStack(alignment: .leading, spacing: .defaultSpacing) {
       HStack {
         Text("내 영양 점수는?")
-          .font(.notoSans(weight: .medium, size: 18))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize))
 
         Spacer()
 
@@ -84,7 +84,7 @@ struct ScoreView: View {
               .font(.notoSans(weight: .medium, size: 50))
 
             Text("점")
-              .font(.notoSans(weight: .medium, size: 20))
+              .font(.notoSans(weight: .medium, size: .defaultFontSize + 2))
           }
           .padding(.bottom, 24)
 
@@ -93,7 +93,7 @@ struct ScoreView: View {
 
 
             Text(statusMessage)
-              .font(.notoSans(weight: .medium, size: 14))
+              .font(.notoSans(weight: .medium, size: .defaultFontSize - 4))
               .foregroundColor(.gray)
           }        }
         .padding(.bottom, 36)

--- a/Meditory/Meditory/Features/Recommend/View/ScrapView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/ScrapView.swift
@@ -64,7 +64,7 @@ struct NutrientCardCell: View {
       VStack(alignment: .leading, spacing: .smallSpacing) {
         HStack {
           Text(nutrient.name)
-            .font(.notoSans(weight: .medium, size: 15))
+            .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
 
           Spacer()
 
@@ -80,7 +80,7 @@ struct NutrientCardCell: View {
         HStack {
           ForEach(nutrient.hashtags.prefix(2), id: \.self) { tag in
             Text("#\(tag)")
-              .font(.notoSans(weight: .medium, size: 12))
+              .font(.notoSans(weight: .medium, size: .defaultFontSize - 6))
               .lineLimit(1)
           }
         }

--- a/Meditory/Meditory/Features/Recommend/View/SearchCardView.swift
+++ b/Meditory/Meditory/Features/Recommend/View/SearchCardView.swift
@@ -38,11 +38,11 @@ struct SearchCardView: View {
 
       VStack(alignment: .leading) {
         Text(brand)
-          .font(.notoSans(weight: .medium, size: 15))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize - 3))
           .foregroundColor(.secondary)
 
         Text(productName)
-          .font(.notoSans(weight: .medium, size: 16))
+          .font(.notoSans(weight: .medium, size: .defaultFontSize - 2))
           .lineLimit(2)
       }
 

--- a/Meditory/Meditory/Features/Setting/View/SettingSubView.swift
+++ b/Meditory/Meditory/Features/Setting/View/SettingSubView.swift
@@ -11,8 +11,6 @@ struct SettingSubView: View {
   // DB에서 User 목록을 가져오기 위함
   @Query private var users: [User]
   
-  private let defaultFontSize: CGFloat = 18
-  
   var body: some View {
     // users 배열에서 첫 번째 사용자를 가져옴
     let currentUser = users.first
@@ -132,7 +130,7 @@ struct SettingSubView: View {
       HStack {
         Text(title)
           // .font 파라미터 순서를 weight -> size로 수정함
-          .font(.notoSans(size: defaultFontSize))
+          .font(.notoSans(size: .defaultFontSize))
           .foregroundStyle(.primary)
         
         Spacer()

--- a/Meditory/Meditory/Features/Setting/View/SettingView.swift
+++ b/Meditory/Meditory/Features/Setting/View/SettingView.swift
@@ -10,8 +10,6 @@ struct SettingView: View {
   @Environment(\.scenePhase) private var scenePhase
   @State private var viewModel: SettingViewModel
   
-  private let defaultFontSize: CGFloat = 18
-  
   init() {
       // 앱의 실제 Store 싱글턴을 주입함
       _viewModel = State(initialValue: SettingViewModel(settingStore: SettingStore.shared))
@@ -39,7 +37,7 @@ struct SettingView: View {
         NavigationLink(destination: SettingSubView()) {
           settingItem {
             Text("내 정보 ∙ 건강 정보 관리")
-              .font(.notoSans(size: defaultFontSize))
+              .font(.notoSans(size: .defaultFontSize))
               .foregroundStyle(.primary)
           }
         }
@@ -51,13 +49,13 @@ struct SettingView: View {
           } label: {
             HStack {
               Text("알림")
-                .font(.notoSans(size: 18))
+                .font(.notoSans(size: .defaultFontSize))
                 .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity, alignment: .leading) // 레이아웃을 전체 너비로 확장함
                 .contentShape(Rectangle()) // 터치 영역을 사각형 프레임 전체로 확장함
               
               Text(viewModel.isSystemGranted ? "ON" : "OFF")
-                .font(.caption)
+                .font(.notoSans(size: .defaultFontSize - 4))
                 .foregroundColor(.secondary)
                 .padding(.trailing, 4)
             }
@@ -71,7 +69,7 @@ struct SettingView: View {
             Link(destination: url) {
               HStack {
                 Text("고객센터 문의하기")
-                  .font(.notoSans(size: defaultFontSize))
+                  .font(.notoSans(size: .defaultFontSize))
                   .foregroundStyle(.primary) // 링크의 기본 파란색 스타일을 덮어쓰기 위함
                   .frame(maxWidth: .infinity, alignment: .leading) // 레이아웃을 전체 너비로 확장함
                   .contentShape(Rectangle()) // 터치 영역을 사각형 프레임 전체로 확장함

--- a/Meditory/Meditory/Features/SupplementDetail/Components/Guide/SupplementGuideCard.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/Components/Guide/SupplementGuideCard.swift
@@ -53,9 +53,9 @@ struct SupplementInfoCard: View {
   @Environment(\.colorScheme) private var colorScheme
   @Environment(\.horizontalSizeClass) private var hSize
   private var isPadStyle: Bool { hSize == .regular }
-  private var titleFontSize: CGFloat { isPadStyle ? 20 : 18 }
-  private var subtitleFontSize: CGFloat { isPadStyle ? 16 : 14 }
-  private var textFontSize: CGFloat { isPadStyle ? 17 : 15 }
+  private var titleFontSize: CGFloat { .defaultFontSize }
+  private var subtitleFontSize: CGFloat { .defaultFontSize - 4 }
+  private var textFontSize: CGFloat { .defaultFontSize - 3 }
 
   let mode: Mode
 

--- a/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/IconBadge.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/IconBadge.swift
@@ -18,7 +18,7 @@ struct IconBadge: View {
         .fill(backgroundColor)
 
       Image(systemName: systemName)
-        .font(.notoSans(size: 14))
+        .font(.notoSans(size: .defaultFontSize - 4))
         .fontWeight(.semibold)
         .foregroundStyle(foregroundColor)
     }

--- a/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/SchedulePanel.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/SchedulePanel.swift
@@ -21,7 +21,7 @@ struct SchedulePanel: View {
           .foregroundStyle(.orange)
 
         Text("복용 스케줄")
-          .font(.notoSans(size: 18))
+          .font(.notoSans(size: .defaultFontSize))
           .fontWeight(.bold)
 
         Spacer()
@@ -57,10 +57,10 @@ struct SchedulePanel: View {
         HStack(spacing: .smallSpacing) {
           Image(systemName: "square.and.pencil")
           Text("내 일정 수정 하러 가기")
-            .font(.notoSans(weight: .bold, size: 15))
+            .font(.notoSans(weight: .bold, size: .defaultFontSize - 3))
           Spacer()
           Image(systemName: "chevron.right")
-            .font(.notoSans(weight: .semiBold, size: 15))
+            .font(.notoSans(weight: .semiBold, size: .defaultFontSize - 3))
         }
         .padding(.vertical, .defaultSpacing)
         .padding(.horizontal, .defaultSpacing)

--- a/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/SectionHeader.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/SectionHeader.swift
@@ -27,7 +27,7 @@ struct SectionHeader: View {
       }
 
       Text(title)
-        .font(.notoSans(size: 13))
+        .font(.notoSans(size: .defaultFontSize - 5))
         .foregroundStyle(colorScheme == .dark ? .white : .main)
     }
     .padding(.horizontal, .smallSpacing)

--- a/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/TimeRow.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/TimeRow.swift
@@ -26,13 +26,13 @@ struct TimeRow: View {
 
       if !period.isEmpty {
         Text(period)
-          .font(.notoSans(size: 14))
+          .font(.notoSans(size: .defaultFontSize - 4))
           .fontWeight(.semibold)
           .foregroundStyle(.secondary)
       }
 
       Text(hm.isEmpty ? timeText : hm)
-        .font(.notoSans(size: 15))
+        .font(.notoSans(size: .defaultFontSize - 3))
         .fontWeight(.bold)
         .foregroundStyle(pointColor)
 
@@ -43,7 +43,7 @@ struct TimeRow: View {
           .imageScale(.small)
 
         Text(pills)
-          .font(.notoSans(size: 13))
+          .font(.notoSans(size: .defaultFontSize - 5))
       }
       .padding(.horizontal, .smallSpacing)
       .padding(.vertical, .smallSpacing)

--- a/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/WeekdayChips.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/Components/Schedule/WeekdayChips.swift
@@ -15,7 +15,7 @@ struct WeekdayChips: View {
       Spacer(minLength: 0)
       ForEach(weekdays, id: \.self) { text in
         Text(text)
-          .font(.notoSans(size: 13))
+          .font(.notoSans(size: .defaultFontSize - 5))
           .fontWeight(.semibold)
           .padding(.horizontal, .smallSpacing)
           .padding(.vertical, .smallSpacing / 2)

--- a/Meditory/Meditory/Features/SupplementDetail/View/SupplementDetailView.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/View/SupplementDetailView.swift
@@ -146,7 +146,7 @@ struct SupplementDetailView: View {
       showDeleteAlert = true
     } label: {
       Label("루틴 삭제", systemImage: "trash.fill")
-        .font(.notoSans(weight: .bold, size: 17))
+        .font(.notoSans(weight: .bold, size: .defaultFontSize - 1))
         .frame(maxWidth: .infinity)
         .padding(.vertical, .defaultSpacing)
     }
@@ -183,7 +183,7 @@ extension SupplementDetailView {
 
         VStack(spacing: .defaultSpacing * 2) {
           Text("정말 삭제하시겠어요?")
-            .font(.notoSans(size: 24))
+            .font(.notoSans(size: .defaultFontSize + 6))
             .fontWeight(.bold)
             .multilineTextAlignment(.center)
 
@@ -191,7 +191,7 @@ extension SupplementDetailView {
             Text("루틴을 삭제하면 복용 기록도 삭제됩니다.")
             Text("삭제하시려면 아래 버튼을 눌러주세요.")
           }
-          .font(.notoSans(weight: .regular, size: 18))
+          .font(.notoSans(weight: .regular, size: .defaultFontSize))
           .foregroundStyle(.secondary)
           .multilineTextAlignment(.center)
 
@@ -200,7 +200,7 @@ extension SupplementDetailView {
               isPresented = false
             } label: {
               Text("아니요")
-                .font(.notoSans(size: 18))
+                .font(.notoSans(size: .defaultFontSize))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, .smallSpacing)
             }
@@ -217,7 +217,7 @@ extension SupplementDetailView {
               isPresented = false
             } label: {
               Text("삭제")
-                .font(.notoSans(size: 18))
+                .font(.notoSans(size: .defaultFontSize))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, .smallSpacing)
             }

--- a/Meditory/Meditory/Features/SupplementDetail/View/SupplementDetailView.swift
+++ b/Meditory/Meditory/Features/SupplementDetail/View/SupplementDetailView.swift
@@ -70,8 +70,13 @@ struct SupplementDetailView: View {
     .navigationBar(.supplementDetail, isAtTop: isAtTop)
     .overlay {
       if showDeleteAlert {
-        DeleteAlertView(
-          isPresented: $showDeleteAlert,
+        AlertView(
+          alertType: .delete,
+          title: "정말 삭제하시겠어요?",
+          message: "루틴을 삭제하면 복용 기록도 삭제됩니다.\n삭제하시려면 아래 버튼을 눌러주세요.",
+          onCancel: {
+            showDeleteAlert = false
+          },
           onDelete: {
             let pid  = routine.persistentModelID
             let uuid = routine.id
@@ -161,84 +166,6 @@ struct SupplementDetailView: View {
       RoundedRectangle(cornerRadius: .defaultRadius, style: .continuous)
         .stroke(Color.red.opacity(0.2), lineWidth: 1.5)
     )
-  }
-}
-
-extension SupplementDetailView {
-  private struct DeleteAlertView: View {
-    @Binding var isPresented: Bool
-    var onDelete: () -> Void
-
-    @Environment(\.horizontalSizeClass) private var hSize
-
-    private var isPadStyle: Bool { hSize == .regular }
-    private var maxCardWidth: CGFloat { isPadStyle ? 520 : .infinity }
-
-    var body: some View {
-      ZStack {
-        Color.black.opacity(0.35)
-          .ignoresSafeArea()
-          .contentShape(Rectangle())
-          .onTapGesture { isPresented = false }
-
-        VStack(spacing: .defaultSpacing * 2) {
-          Text("정말 삭제하시겠어요?")
-            .font(.notoSans(size: .defaultFontSize + 6))
-            .fontWeight(.bold)
-            .multilineTextAlignment(.center)
-
-          VStack(spacing: .smallSpacing) {
-            Text("루틴을 삭제하면 복용 기록도 삭제됩니다.")
-            Text("삭제하시려면 아래 버튼을 눌러주세요.")
-          }
-          .font(.notoSans(weight: .regular, size: .defaultFontSize))
-          .foregroundStyle(.secondary)
-          .multilineTextAlignment(.center)
-
-          HStack(spacing: .defaultSpacing) {
-            Button {
-              isPresented = false
-            } label: {
-              Text("아니요")
-                .font(.notoSans(size: .defaultFontSize))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, .smallSpacing)
-            }
-            .buttonStyle(.plain)
-            .background(Color.secondary.opacity(0.16))
-            .overlay(
-              RoundedRectangle(cornerRadius: .smallRadius, style: .continuous)
-                .stroke(Color(.systemGray4), lineWidth: 1)
-            )
-            .cornerRadius(.smallRadius)
-
-            Button {
-              onDelete()
-              isPresented = false
-            } label: {
-              Text("삭제")
-                .font(.notoSans(size: .defaultFontSize))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, .smallSpacing)
-            }
-            .foregroundStyle(.white)
-            .background(Color.red)
-            .cornerRadius(.smallRadius)
-          }
-        }
-        .padding(.defaultSpacing + 8)
-        .frame(maxWidth: maxCardWidth, alignment: .center)
-        .background(
-          RoundedRectangle(cornerRadius: .defaultRadius, style: .continuous)
-            .fill(.regularMaterial)
-        )
-        .shadow(color: .black.opacity(0.15), radius: 20, x: 0, y: 10)
-        .padding(.horizontal, .defaultSpacing)
-        .zIndex(1000)
-      }
-      .transition(.opacity)
-      .zIndex(1000)
-    }
   }
 }
 


### PR DESCRIPTION
## 개요
- 영양제 추가화면 UI 아이패드 대응해주었습니다.
- 가로모드일 경우 셀 크기를 디바이스 사이즈의 0.6 정도로 고정해주었습니다
- CGFloat+Extension에 defaultFontSize를 추가해주었습니다.
- 아이패드일 경우 식단 탭에 추가 버튼이 보이지 않는 이슈를 해결하였습니다.
- 식사 안 함 텍스트가 다크모드에서 보이지 않는 이슈를 해결하였습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Notion 팀 페이지 내 Commit Message Convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
